### PR TITLE
Fix tight loop.

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,7 +209,6 @@ func reloadConfig(sigs chan os.Signal) {
 			if err := loadConfig("/etc/nurd/config.json"); err != nil {
 				log.Warning(fmt.Sprintf("Error in reloading /etc/nurd/config.json: %v", err))
 			}
-		default:
 		}
 	}
 }


### PR DESCRIPTION
Having default case causes this to loop, eating up all the CPU. Removing the
default should lower the CPU usage from a constant 100%.